### PR TITLE
Remove nanoid dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "html2canvas": "^1.4.1",
         "jspdf": "^2.5.1",
         "lucide-react": "^0.344.0",
-        "nanoid": "^5.0.6",
         "openai": "^4.28.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -3273,23 +3272,6 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
-      }
-    },
-    "node_modules/nanoid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
-      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
       }
     },
     "node_modules/natural-compare": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "clsx": "^2.1.0",
     "tailwind-merge": "^2.2.1",
     "openai": "^4.28.0",
-    "nanoid": "^5.0.6",
     "html2canvas": "^1.4.1",
     "jspdf": "^2.5.1"
   },


### PR DESCRIPTION
## Summary
- drop unused `nanoid` from dependencies
- refresh `package-lock.json`

## Testing
- `npm install --package-lock-only`
- `npm install` *(fails: ENOTEMPTY rename)*