### PR TITLE
Fix slide count parsing

### DIFF
--- a/src/components/InitialForm.tsx
+++ b/src/components/InitialForm.tsx
@@ -141,7 +141,12 @@ export function InitialForm({ onSubmit, isLoading }: InitialFormProps) {
             min="1"
             max="50"
             value={formData.slideCount}
-            onChange={(e) => setFormData({ ...formData, slideCount: parseInt(e.target.value) })}
+            onChange={(e) =>
+              setFormData({
+                ...formData,
+                slideCount: parseInt(e.target.value, 10),
+              })
+            }
             className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             required
             disabled={isLoading}


### PR DESCRIPTION
## Summary
- ensure slide count uses base 10 when parsing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*