### PR TITLE
Fix README path

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ AIを活用してプレゼンテーションを素早く作成するReactアプ�
 1. リポジトリをクローン
    ```
    git clone https://github.com/yourusername/ai-presentation-generator.git
-   cd ai-presentation-generator
+   cd AI_Presentation_Generator
    ```
 
 2. 依存関係をインストール


### PR DESCRIPTION
## Summary
- update README to use the correct directory name when changing folders after cloning

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*